### PR TITLE
Required Moodle version is missing numbers

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,6 +26,6 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_uploadenrolmentmethods';
 $plugin->version   = 2020120201;        // The current module version.
-$plugin->requires  = 20180517;        // Requires Moodle version 3.5 or higher.
+$plugin->requires  = 2018051700;        // Requires Moodle version 3.5 or higher.
 $plugin->release   = '1.3.1';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Added the entire build number for Moodle 3.5.