### PR TITLE
Missing strings cause warnings

### DIFF
--- a/lang/en/tool_uploadenrolmentmethods.php
+++ b/lang/en/tool_uploadenrolmentmethods.php
@@ -60,3 +60,5 @@ $string['result']                = 'Result';
 $string['results']               = 'Upload enrolment methods results';
 $string['targetisparent']        = 'Method is a parent of the course, so cannot be added as its target.';
 $string['targetnotfound']        = 'Unknown course.';
+$string['uploadenrolmentmethods:add'] = 'Add/Upload enrolment methods';
+$string['uploadenrolmentmethods:delete'] = 'Delete enrolment methods';


### PR DESCRIPTION
Solution for https://github.com/ecampbell/moodle-tool_uploadenrolmentmethods/issues/11