### PR TITLE
Moodle 41 test behat fix

### DIFF
--- a/lang/en/tool_uploadenrolmentmethods.php
+++ b/lang/en/tool_uploadenrolmentmethods.php
@@ -64,3 +64,4 @@ $string['targetisparent'] = 'Method is a parent of the course, so cannot be adde
 $string['targetnotfound'] = 'Unknown course.';
 $string['uploadenrolmentmethods:add'] = 'Add/Upload enrolment methods';
 $string['uploadenrolmentmethods:delete'] = 'Delete enrolment methods';
+$string['uploadthisfile'] = 'Upload csv file';

--- a/tests/behat/uploadenrolmentmethods_cohort.feature
+++ b/tests/behat/uploadenrolmentmethods_cohort.feature
@@ -16,31 +16,29 @@ Feature: Linking cohorts and target courses by uploading a CSV file.
     Given the following "cohorts" exist:
       | name   | idnumber |
       | Cohort 1 | cohort1  |
-    Given the following "cohort enrolments" exist:
+    Given the following "cohort members" exist:
       | cohort  | user   |
       | cohort1 | student1 |
     Given I log in as "admin"
-    And I navigate to "Manage enrol plugins" node in "Site administration > Plugins > Enrolments"
+    And I navigate to "Plugins > Manage enrol plugins" in site administration
+    And I click on "Disable" "link" in the "Cohort sync" "table_row"
     And I click on "Enable" "link" in the "Cohort sync" "table_row"
     And I am on course index
 
-  @_file_upload
+  @javascript @_file_upload
   Scenario: Administrator can upload a CSV file using the upload enrolment methods plugin
     When I log in as "admin"
-    And I navigate to "Upload enrolment methods" node in "Site administration > Plugins > Enrolments"
-    And I upload "admin/tool/uploadenrolmentmethods/tests/fixtures/enrolmentmethod_cohort.csv" file to "Upload this file" filemanager
+    And I navigate to "Plugins > Upload enrolment methods" in site administration
+    And I upload "admin/tool/uploadenrolmentmethods/tests/fixtures/enrolmentmethod_cohort.csv" file to "File" filemanager
     And I click on "id_submitbutton" "button"
-    And I expand "My courses" node
-    And I follow "C102"
-    And I click on "Participants"
+    When I am on the "C101" "course" page logged in as "admin"
+    And I follow "Participants"
     Then I should see "Student1"
     And I should not see "Teacher1"
 
   Scenario: Warning should be displayed a message if cohort sync enrolment is not activated
     Given I log in as "admin"
-    And I navigate to "Manage enrol plugins" node in "Site administration > Plugins > Enrolments"
+    And I navigate to "Plugins > Manage enrol plugins" in site administration
     And I click on "Disable" "link" in the "Cohort sync" "table_row"
-    And I click on "Site administration"
-    And I click on "Plugins"
-    And I click on "Upload enrolment methods"
-    Then I should see "Enrolment method ""Cohort sync"": Disabled"
+    And I navigate to "Plugins > Upload enrolment methods" in site administration
+    Then I should see "Enrolment method \"Cohort sync\" disabled."

--- a/tests/behat/uploadenrolmentmethods_meta.feature
+++ b/tests/behat/uploadenrolmentmethods_meta.feature
@@ -16,27 +16,25 @@ Feature: Linking metacourses and target courses by uploading a CSV file.
     Given the following "course enrolments" exist:
       | user      | course | role           |
       | student1  | C101   | student        |
-      | teacher1  | C101   | editingteacher |
     Given I log in as "admin"
-    And I navigate to "Manage enrol plugins" node in "Site administration > Plugins > Enrolments"
+    And I navigate to "Plugins > Manage enrol plugins" in site administration
     And I click on "Enable" "link" in the "Course meta link" "table_row"
     And I am on course index
 
-  @_file_upload
+  @javascript @_file_upload
   Scenario: Administrator can upload a CSV file using the upload enrolment methods plugin
-    When I log in as "admin"
-    And I navigate to "Upload enrolment methods" node in "Site administration > Plugins > Enrolments"
-    And I upload "admin/tool/uploadenrolmentmethods/tests/fixtures/enrolmentmethod_meta.csv" file to "Upload this file" filemanager
+    Given I log in as "admin"
+    And I navigate to "Plugins > Upload enrolment methods" in site administration
+    When I upload "admin/tool/uploadenrolmentmethods/tests/fixtures/enrolmentmethod_meta.csv" file to "File" filemanager
     And I click on "id_submitbutton" "button"
-    And I expand "My courses" node
-    And I follow "C102"
-    And I click on "Participants"
+    When I am on the "C102" "course" page logged in as "admin"
+    And I follow "Participants"
     Then I should see "Student1"
     And I should not see "Teacher1"
 
   Scenario: Warning should be displayed if meta enrolment is not activated
     Given I log in as "admin"
-    And I navigate to "Manage enrol plugins" node in "Site administration > Plugins > Enrolments"
+    And I navigate to "Plugins > Manage enrol plugins" in site administration
     And I click on "Disable" "link" in the "Course meta link" "table_row"
-    And I navigate to "Upload enrolment methods" node in "Site administration > Plugins > Enrolments"
-    Then I should see "Enrolment method ""Course meta link"": Disabled"
+    And I navigate to "Plugins > Upload enrolment methods" in site administration
+    And I should see "Enrolment method \"Course meta link\" disabled."

--- a/tests/fixtures/enrolmentmethod_cohort.csv
+++ b/tests/fixtures/enrolmentmethod_cohort.csv
@@ -1,2 +1,3 @@
+operation,method,shortname,metacohort,disabled,group
 add,cohort,C101,cohort1,0,Cohort group 1
 upd,cohort,C101,cohort1,1,

--- a/tests/fixtures/enrolmentmethod_meta.csv
+++ b/tests/fixtures/enrolmentmethod_meta.csv
@@ -1,2 +1,3 @@
+operation,method,shortname,metacohort,disabled,group
 add,meta,C102,C101,0,Meta Group 1
 upd,meta,C102,C101,1,

--- a/uploadenrolmentmethods_form.php
+++ b/uploadenrolmentmethods_form.php
@@ -64,7 +64,7 @@ class uploadenrolmentmethods_form extends moodleform {
         $mform->addHelpButton('encoding', 'encoding', 'tool_uploadcourse');
 
         // Standard buttons.
-        $this->add_action_buttons(true, get_string('uploadthisfile'));
+        $this->add_action_buttons(true, get_string('uploadthisfile', 'tool_uploadenrolmentmethods'));
     }
 
     /**


### PR DESCRIPTION

The tests behat are not working with the Moodle version 4.1 due to the different web design of the application.
In this code:
- I've updated one string because it was in conflict with the Behat module called filemanager
- I've updated the syntaxe of the behat tests in order to be inline with the new version
- I've updated the csv file to add columns

After those improvements, it is working correctly:

root@61248ecb9ebf:/var/www/html# vendor/bin/behat --config /var/www/behatdata/behatrun/behat/behat.yml --tags=@tool_uploadenrolmentmethods
Moodle 4.1.6 (Build: 20231009, Build StudiUM: 20231019), 4fa122b40a5c4d85dcfb20c1553b5179321452c6
Php: 8.1.24, mysqli: 8.0.34, OS: Linux 6.2.0-36-generic x86_64
Run optional tests:
- Accessibility: Yes
Server OS "Linux", Browser: "chrome"
Started at 18-11-2023, 04:09
..........................................................

4 scenarios (4 passed)
58 steps (58 passed)
10m41.94s (65.51Mb)
